### PR TITLE
Bind Apache intranet VirtualHosts to private IP address

### DIFF
--- a/roles/apache/templates/intranet-qbittorrent.conf.j2
+++ b/roles/apache/templates/intranet-qbittorrent.conf.j2
@@ -1,5 +1,5 @@
-<VirtualHost *:80>
-  ServerName qbittorrent.intranet.{{ domain}}
+<VirtualHost {{ private_ip_address }}:80>
+  ServerName qbittorrent.intranet.{{ domain }}
 
   DocumentRoot /var/apache2/intranet/www/
   <Directory /var/apache2/intranet/www/>
@@ -20,8 +20,8 @@
   RewriteRule (.*) https://%{HTTP_HOST}/$1 [L,R=301]
 </VirtualHost>
 
-<VirtualHost *:443>
-  ServerName qbittorrent.intranet.{{ domain}}
+<VirtualHost {{ private_ip_address }}:443>
+  ServerName qbittorrent.intranet.{{ domain }}
 
   DocumentRoot /var/apache2/intranet/www/
   <Directory /var/apache2/intranet/www/>

--- a/roles/apache/templates/intranet.conf.j2
+++ b/roles/apache/templates/intranet.conf.j2
@@ -1,4 +1,4 @@
-<VirtualHost *:80>
+<VirtualHost {{ private_ip_address }}:80>
   ServerName intranet.{{ domain}}
 
   DocumentRoot /var/apache2/intranet/www/
@@ -21,8 +21,8 @@
   RewriteRule (.*) https://%{HTTP_HOST}/$1 [L,R=301]
 </VirtualHost>
 
-<VirtualHost *:443>
-  ServerName intranet.{{ domain}}
+<VirtualHost {{ private_ip_address }}:443>
+  ServerName intranet.{{ domain }}
 
   DocumentRoot /var/apache2/intranet/www/
   <Directory /var/apache2/intranet/www/>


### PR DESCRIPTION
## Summary
- Change VirtualHost directives from wildcard (*) to bind to specific private IP address
- Improves security posture by preventing intranet services from being accessible on all network interfaces
- Affects intranet.conf.j2 and intranet-qbittorrent.conf.j2 templates

## Test plan
- [x] Changes tested and verified to work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)