### PR TITLE
Add VSZ memory limit to Dovecot IMAP service

### DIFF
--- a/roles/mail_server/templates/dovecot/10-master.conf.j2
+++ b/roles/mail_server/templates/dovecot/10-master.conf.j2
@@ -64,6 +64,7 @@ service imap {
   # Most of the memory goes to mmap()ing files. You may need to increase this
   # limit if you have huge mailboxes.
   #vsz_limit = $default_vsz_limit
+  vsz_limit = 512M
 
   # Max. number of IMAP processes (connections)
   #process_limit = 1024


### PR DESCRIPTION
## Summary
- Add 512M VSZ (Virtual Memory Size) limit to IMAP service configuration
- Prevents excessive virtual memory usage by IMAP processes
- Improves mail server resource management and stability

## Test plan
- [x] Changes tested and verified to work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)