### PR TITLE
Optimize Ansible SSH connection performance

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -23,3 +23,5 @@ callbacks_enabled = profile_tasks, profile_roles
 
 [ssh_connection]
 pipelining = True
+ssh_args = -o ControlMaster=auto -o ControlPersist=3600
+control_path = ~/.ansible/cp/%%C


### PR DESCRIPTION
## Summary
- Add SSH ControlMaster settings to reduce connection overhead during playbook runs
- Automatically reuse SSH connections instead of establishing new ones for each task
- Keep connections alive for 1 hour to improve performance on repeated runs

## Test plan
- [ ] Verify playbook runs work correctly in local environment
- [ ] Test with AWS-based testing infrastructure to ensure compatibility
- [ ] Confirm no SSH connection issues on both macOS and Linux systems

🤖 Generated with [Claude Code](https://claude.ai/code)