### PR TITLE
Remove unused external Ansible roles

### DIFF
--- a/install_roles.yml
+++ b/install_roles.yml
@@ -1,22 +1,8 @@
 ---
 # Run the following command against this file to install all of the Ansible roles required by this project:
-# 
+#
 #     $ ansible-galaxy install --force --role-file=install_roles.yml
-
-# https://github.com/geerlingguy/ansible-role-certbot
-# Manages the 'Certbot' client for Let's Encrypt, which can be used to register
-# and renew free SSL certificates.
-#- src: geerlingguy.certbot
-# TODO: switch back to main releases once <https://github.com/simonspa/ansible-role-certbot.git>
-# is merged.
-- src: 'https://github.com/simonspa/ansible-role-certbot.git'
-  version: 'webroot'
-  name: geerlingguy.certbot
 
 # https://galaxy.ansible.com/karlmdavis/tested-bind/
 # Installs and configures the BIND DNS server.
 - src: karlmdavis.bind-dns
-
-# https://galaxy.ansible.com/geerlingguy/java/
-# Installs and configures Java.
-- src: geerlingguy.java


### PR DESCRIPTION
## Summary
- Remove `geerlingguy.certbot` and `geerlingguy.java` roles from install_roles.yml
- These roles are no longer used in the current infrastructure setup
- Project uses custom snap-based certbot implementation instead of external role

## Test plan
- [ ] Run `ansible-galaxy install -r install_roles.yml` to verify remaining roles install correctly
- [ ] Verify full playbook runs work without the removed roles
- [ ] Confirm no references to these roles exist in the codebase (verified via grep)

## Background
The `geerlingguy.certbot` role has been replaced with a custom implementation using snap packages (see `roles/apache/tasks/certbot.yml`). The `geerlingguy.java` role is no longer needed for current service configurations.

🤖 Generated with [Claude Code](https://claude.ai/code)