### PR TITLE
Fix test script logging: Use ansible-playbook directly instead of wrapper

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -169,24 +169,24 @@ echo ""
 
 # If there is no test inventory, provision the test systems.
 if [[ ! -e ./test/hosts-test ]]; then
-  echo "$ ./ansible-playbook-wrapper test/provision.yml --extra-vars '${EXTRA_VARS}' ${verboseArg}" | tee -a "${originalLog}"
-  ./ansible-playbook-wrapper test/provision.yml --extra-vars "${EXTRA_VARS}" ${verboseArg}
+  echo "$ uv run ansible-playbook test/provision.yml --extra-vars '${EXTRA_VARS}' ${verboseArg}" | tee -a "${originalLog}"
+  uv run ansible-playbook test/provision.yml --extra-vars "${EXTRA_VARS}" ${verboseArg}
   errorCode=$?
   echo -e "\n" | tee -a "${originalLog}"
 fi
 
 # Run our Ansible plays against the test systems.
 if [ $errorCode -eq 0 ] && [ "${configure}" = true ]; then
-  echo "$ ./ansible-playbook-wrapper site.yml --inventory-file=test/hosts-test --extra-vars '${EXTRA_VARS}' --extra-vars \"{is_test: true}\" ${verboseArg}" | tee -a "${originalLog}"
-  ./ansible-playbook-wrapper site.yml --inventory-file=test/hosts-test --extra-vars "${EXTRA_VARS}" --extra-vars "{is_test: true}" ${verboseArg}
+  echo "$ uv run ansible-playbook site.yml --inventory-file=test/hosts-test --extra-vars '${EXTRA_VARS}' --extra-vars \"{is_test: true}\" ${verboseArg}" | tee -a "${originalLog}"
+  uv run ansible-playbook site.yml --inventory-file=test/hosts-test --extra-vars "${EXTRA_VARS}" --extra-vars "{is_test: true}" ${verboseArg}
   errorCode=$?
   echo -e "\n" | tee -a "${originalLog}"
 fi
 
 # Tear down the test systems.
 if [ $errorCode -eq 0 ] && [ "${teardown}" = true ]; then
-  echo "$ ./ansible-playbook-wrapper test/teardown.yml --inventory-file=test/hosts-test --extra-vars '${EXTRA_VARS}' ${verboseArg}" | tee -a "${originalLog}"
-  ./ansible-playbook-wrapper test/teardown.yml --inventory-file=test/hosts-test --extra-vars "${EXTRA_VARS}" ${verboseArg}
+  echo "$ uv run ansible-playbook test/teardown.yml --inventory-file=test/hosts-test --extra-vars '${EXTRA_VARS}' ${verboseArg}" | tee -a "${originalLog}"
+  uv run ansible-playbook test/teardown.yml --inventory-file=test/hosts-test --extra-vars "${EXTRA_VARS}" ${verboseArg}
   errorCode=$?
   echo -e "\n" | tee -a "${originalLog}"
 


### PR DESCRIPTION
## Summary

Fixes the test script's log management by calling `ansible-playbook` directly instead of using the `ansible-playbook-wrapper`, which was interfering with the consolidated logging strategy.

## Problem

The `test.sh` script implements its own log management strategy:
1. Accumulates all output from multiple playbook runs into a single `ansible.log` file
2. Renames it once at the end to `ansible-test-${timestamp}.log` for a consolidated test run log

However, calling `ansible-playbook-wrapper` conflicted with this approach because:
- The wrapper creates its own timestamp for each invocation
- It immediately renames the log to `ansible-production-${timestamp}.log` after each playbook run
- This resulted in multiple fragmented log files instead of one consolidated test log

## Solution

Replace all `ansible-playbook-wrapper` calls with `uv run ansible-playbook` in `test.sh`:
- Preserves the `uv` environment management (the key functionality from the wrapper)
- Allows `test.sh`'s log management to work as intended
- Produces a single consolidated log file per test run

## Changes

Updated three playbook invocations in `test/test.sh`:
- **Provisioning** (line 173): `test/provision.yml`
- **Configuration** (line 181): `site.yml`
- **Teardown** (line 189): `test/teardown.yml`

All now use `uv run ansible-playbook` directly instead of `./ansible-playbook-wrapper`.

## Benefits

- ✅ Single consolidated log file per test run (`ansible-test-TIMESTAMP.log`)
- ✅ Easier debugging with all test output in one place
- ✅ Consistent log file naming and organization
- ✅ No change to environment management or playbook execution

## Testing

The fix should be validated by running a test cycle and verifying:
1. Only one log file is created per test run
2. The log contains output from all three playbook invocations
3. The log filename follows the pattern `ansible-test-YYYY-MM-DDTHH:MM:SS+ZZZZ.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>