### PR TITLE
Hardcode Ansible Homebrew `PATH` during `chezmoi` install

### DIFF
--- a/roles/user_karl/tasks/main.yml
+++ b/roles/user_karl/tasks/main.yml
@@ -83,10 +83,13 @@
     mode: u=rw,g=r,o=r
   become: true
 
+# Full path to `brew` is required for weird Ansible+sudo reasons,
+# see https://github.com/karlmdavis/justdavis-ansible/issues/66 for details.
 - name: Install chezmoi Using Homebrew
   community.general.homebrew:
     name: chezmoi
     state: present
+    path: "{{ brew_prefix }}/bin"
   become_user: "{{ user_karl_target_user }}"
   become: true
 


### PR DESCRIPTION
This PR does the following:

- [x] Solves #66 
- [x] Added the `path: "{{ brew_prefix }}/bin"` parameter to the `community.general.homebrew` task that
  installs `chezmoi` for the `user_karl_target_user` user.
- [x] Added a clarifying comment explaining why the full path is required.

### Why this change is needed

When running Ansible tasks with `become: true`, `sudo` resets the environment and strips down the `PATH`
defined by the `secure_path` variable in `/etc/sudoers`.

As a result, binaries installed via Homebrew may not be found unless the remote login user matches the
target `user_karl_target_user`. Without this change, tasks installing or using Homebrew-managed software
can fail unpredictably depending on which management account runs the playbook.

### Explanation of sudo + Ansible behavior

- By default, `become` (sudo) sanitizes the environment, resetting `PATH`.
- If the controller user differs from the target remote user, the Homebrew directories are removed from
  the effective `PATH`.
- Hardcoding the path to `brew` ensures that Ansible can reliably locate and execute Homebrew commands,
  regardless of the invoking user.

### BECOME_ALLOW_SAME_USER

The behavior above is influenced by the Ansible configuration option `BECOME_ALLOW_SAME_USER`. When the
management user matches the remote target user, Ansible allows the task to inherit the login environment,
so the Homebrew path may already be present. However, relying on this behavior is fragile.

See the official Ansible docs for details:

- https://docs.ansible.com/projects/ansible/latest/reference_appendices/config.html#become-allow-same-user

### Alternative Solution (_that wasn't implemented_)

Setting the `become_flags: "-i"` forces the remote user to enter into a login shell, which will run the
`/etc/profile.d/homebrew.sh` script to load the Homebrew path. However, this introduces more magic into
the playbook and is less deterministic. For example, now this task _depends on `user_karl_target_user`'s dotfiles/shell-environment._

### Useful Troubleshooting Commands

```bash
# Show all Ansible configuration, including become behavior:
$ uv run ansible-config dump -vv

# Check the PATH seen by the target user without a login shell:
$ ssh <remote_user>@<host> 'sudo -u karl env | grep ^PATH='

# Check the PATH seen by the target user in a login shell:
$ ssh <remote_user>@<host> 'sudo -i -u karl env | grep ^PATH='

# Inspect the secure_path configured in sudoers:
$ ssh <remote_user>@<host> 'sudo -u karl grep "secure_path" /etc/sudoers'
```