### PR TITLE
Fix `saslauthd` authentication in Postfix chroot

### DIFF
--- a/roles/ldap_server/tasks/sasl-authd.yml
+++ b/roles/ldap_server/tasks/sasl-authd.yml
@@ -16,6 +16,35 @@
     - sasl2-bin
   become: true
 
+- name: Ensure sasl Group Exists
+  ansible.builtin.group:
+    name: sasl
+    state: present
+    system: true
+  become: true
+
+- name: Create Parent Directories for saslauthd Socket
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: u=rwx,g=rx,o=rx
+  with_items:
+    - /var/spool/postfix
+    - /var/spool/postfix/var
+    - /var/spool/postfix/var/run
+  become: true
+
+- name: Create saslauthd Socket Directory in Postfix Chroot
+  ansible.builtin.file:
+    path: /var/spool/postfix/var/run/saslauthd
+    state: directory
+    owner: root
+    group: sasl
+    mode: u=rwx,g=rwx,o=
+  become: true
+
 - name: Configure saslauthd Defaults
   ansible.builtin.lineinfile:
     dest: /etc/default/saslauthd
@@ -24,6 +53,29 @@
   with_dict:
     '.*START=.*': 'START=yes'
     '.*MECHANISMS=.*': 'MECHANISMS="kerberos5"'
+    '.*OPTIONS=.*': 'OPTIONS="-c -m /var/spool/postfix/var/run/saslauthd"'
+  become: true
+  notify:
+    - "Restart 'saslauthd'"
+
+- name: Create systemd Override Directory for saslauthd
+  ansible.builtin.file:
+    path: /etc/systemd/system/saslauthd.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: u=rwx,g=rx,o=rx
+  become: true
+
+- name: Configure systemd PID File Override for saslauthd
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/saslauthd.service.d/pidfile.conf
+    owner: root
+    group: root
+    mode: u=rw,g=r,o=r
+    content: |
+      [Service]
+      PIDFile=/var/spool/postfix/var/run/saslauthd/saslauthd.pid
   become: true
   notify:
     - "Restart 'saslauthd'"
@@ -36,7 +88,7 @@
     daemon_reload: true
   become: true
 
-- name: Configure OpenLDAP for saslauthd
+- name: Configure OpenLDAP for saslauthd - Method
   ansible.builtin.lineinfile:
     dest: /etc/ldap/sasl2/slapd.conf
     owner: root
@@ -45,6 +97,18 @@
     create: true
     regexp: '^pwcheck_method: .*'
     line: 'pwcheck_method: saslauthd'
+  become: true
+  notify:
+    - "Restart 'slapd'"
+
+- name: Configure OpenLDAP for saslauthd - Socket Path
+  ansible.builtin.lineinfile:
+    dest: /etc/ldap/sasl2/slapd.conf
+    owner: root
+    group: root
+    mode: u=rw,g=rw,o=r
+    regexp: '^saslauthd_path: .*'
+    line: 'saslauthd_path: /var/spool/postfix/var/run/saslauthd/mux'
   become: true
   notify:
     - "Restart 'slapd'"

--- a/roles/ldap_server/tasks/test.yml
+++ b/roles/ldap_server/tasks/test.yml
@@ -20,7 +20,7 @@
 
 - name: 'Test saslauthd'
   ansible.builtin.command:
-    cmd: "/usr/sbin/testsaslauthd -u {{ test_username }} -p {{ test_password }}"
+    cmd: "/usr/sbin/testsaslauthd -u {{ test_username }} -p {{ test_password }} -f /var/spool/postfix/var/run/saslauthd/mux"
   become: true
   no_log: true
   register: testsaslauthd_result

--- a/roles/ldap_server/templates/slapd-apparmor.j2
+++ b/roles/ldap_server/templates/slapd-apparmor.j2
@@ -9,5 +9,5 @@
 /etc/letsencrypt/live/** r,
 /etc/letsencrypt/archive/** r,
 
-# Add read access to saslauthd.
-/run/saslauthd/mux rw,
+# Add read access to saslauthd (located in Postfix chroot for shared access).
+/var/spool/postfix/var/run/saslauthd/mux rw,

--- a/roles/mail_server/tasks/sasl-chroot-fix.yml
+++ b/roles/mail_server/tasks/sasl-chroot-fix.yml
@@ -5,10 +5,12 @@
 # service is (by default) run inside a chroot environment at
 # `/var/spool/postfix/`, which doesn't have access to the SASL socket file.
 #
-# This config adds that file (and friends) back into the chroot environment
-# using a mount bind. This fix is taken from here:
-# <https://github.com/webmin/webmin/issues/58>, which is the only halfway
-# decent solution to this problem I managed to come across.
+# The standard Debian solution is to configure saslauthd to create its socket
+# directly inside the Postfix chroot at `/var/spool/postfix/var/run/saslauthd`.
+# This requires creating the directory structure and setting proper permissions
+# so both Postfix and saslauthd can access it.
+#
+# Reference: /etc/default/saslauthd comments on Debian/Ubuntu systems.
 ##
 
 - name: Add 'postfix' User to 'sasl' Group
@@ -30,7 +32,7 @@
     - /var/spool/postfix/var/run
   become: true
 
-- name: Create Mount Point for SASL in Postfix chroot
+- name: Create SASL Directory in Postfix chroot
   ansible.builtin.file:
     state: directory
     path: /var/spool/postfix/var/run/saslauthd
@@ -39,24 +41,15 @@
     mode: u=rwx,g=rwx,o=
   become: true
 
-- name: Verify dpkg Override for SASL Mount Point
+- name: Verify dpkg Override for SASL Directory
   ansible.builtin.command:
     cmd: dpkg-statoverride --list /var/spool/postfix/var
   register: dpkg_override_postfix_var
   changed_when: false
   failed_when: false
 
-- name: Configure dpkg to Handle SASL Mount Point Correctly
+- name: Configure dpkg to Handle SASL Directory Correctly
   ansible.builtin.command:
     cmd: dpkg-statoverride --add root root 755 /var/spool/postfix/var
   become: true
   when: dpkg_override_postfix_var.rc != 0
-
-- name: Mount SASL in Postfix chroot
-  ansible.posix.mount:
-    name: /var/spool/postfix/var/run/saslauthd
-    src: /var/run/saslauthd
-    fstype: bind
-    opts: defaults,nodev,bind
-    state: mounted
-  become: true


### PR DESCRIPTION
This PR does the following:

- [x] Configures `saslauthd` to create its socket directly inside the Postfix chroot at
  `/var/spool/postfix/var/run/saslauthd` instead of bind-mounting `/run/saslauthd`. (This follows the
  standard Debian/Ubuntu saslauthd configuration model and avoids fragile bind mounts.)
- [x] This adds required directory structure and permissions, updates `saslauthd` defaults and systemd
  PIDFile, adjusts OpenLDAP SASL socket path, updates AppArmor rules, and fixes test commands
  accordingly.
