### PR TITLE
Configure neutral staging location for Ansible Playbook temporary files/data to avoid permissions warnings

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -17,6 +17,14 @@ retry_files_enabled = False
 # Ensure that Ansible output is logged, so that ansible-playbook-wrapper can manage it.
 log_path = ./logs/ansible.log
 
+# Use a neutral remote temp directory to silence Ansible's warning:
+#   "[WARNING]: Module remote_tmp /root/.ansible/tmp did not exist and was created
+#   with a mode of 0700, this may cause issues when running as another user. To
+#   avoid this, create the remote_tmp dir with the correct permissions manually"
+# This happens because Ansible creates remote_tmp in the target user's home with 0700, which
+# breaks become_user scenarios where a different user needs to access the module/task files.
+remote_tmp = /tmp/.ansible-${USER}
+
 # Log how long each Ansible task takes to run.
 # Reference: http://stackoverflow.com/a/29132716/1851299
 callbacks_enabled = profile_tasks, profile_roles


### PR DESCRIPTION
This PR does the following:

- [x] Fixes #69
- [x] Configure a predictable `remote_tmp` at `/tmp/.ansible-${USER}` to prevent permission errors when
  running tasks with `become` or different users.
