### PR TITLE
Increase EC2 instance size to prevent CPU exhaustion

### DIFF
--- a/test/provision.yml
+++ b/test/provision.yml
@@ -133,8 +133,11 @@
     - name: EC2 - Provision 'jordan-u'
       ec2_instance:
         key_name: "{{ aws_ec2_key_name }}"
-        # The `t2.micro` instance type has 1 vCPUs, 1GB RAM, and 6 CPU credits/hour.
-        instance_type: t2.micro
+        # The `t2.small` instance type has 1 vCPUs, 2GB RAM, and 6 CPU credits/hour. For
+        # jordan-u, `t2.medium` seems to be the minimum working number of CPU credits. However,
+        # t2.large provides some future proofing so that CPU credits aren't used up during
+        # burst. See https://github.com/karlmdavis/justdavis-ansible/issues/72
+        instance_type: t2.large
         image_id: "{{ ami_id_ubuntu_24_04 }}"
         user_data: |
                    #!/bin/sh


### PR DESCRIPTION
## Problem Description

Homebrew installs (e.g., Nushell) were causing the instance to become unresponsive on `t2.small` due to CPU credit exhaustion and memory pressure during resource intensive CPU bursts. This manifested as `chezmoi` and Ansible hanging during `brew install`.

## What this PR does

- [x] Fixes #72 
- [x] Upgrades `jordan-u` EC2 instance to `t2.large` to ensure there is sufficient CPU baseline and memory to complete provisioning reliably.