### PR TITLE
Add logs/ directory and ignore files, to fix missing directory errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,6 @@ test/hosts-test
 test/user-config.env
 test/test-session.env
 
-# Ignore the saved Ansible logs. (No way to reasonably version control them; hopefully backups catch them, if needed.)
-logs/
-
 # Ignore vim swp files.
 *.swp
 

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,3 @@
+# This directory needs to be here, per ansible.cfg, so this .gitignore is mostly just a placeholder for the dir.
+# Ignore the saved Ansible logs: they're build logs and sometimes contain sensitive info.
+*


### PR DESCRIPTION
## Problem Description

Upon a fresh clone of this project, `ansible-playbook-wrapper` cannot be run successfully without first
creating the `logs/` directory where it can timestamp and place Ansible logs in. This creates friction
between the developer and this repo.

After a fresh clone of this repository, running `ansible-playbook-wrapper` fails because the `logs/`
directory does not exist. This directory is required for timestamping and storing Ansible logs, and its
absence creates unnecessary friction for developers.

## This PR does the following

- [x] Resolves #64
- [x] Stub out the `logs/` directory and ignore all files within it to prevent
  `No such file or directory` errors when running `ansible-playbook-wrapper` so that this repo is *more*
  "ready to go" upon being cloned.
