### PR TITLE
fix(eddings_networking): update NIC names for new server hardware

### DIFF
--- a/roles/eddings_networking/files/netplan/00-installer-config.yaml
+++ b/roles/eddings_networking/files/netplan/00-installer-config.yaml
@@ -1,9 +1,9 @@
 ##
 # This server has the following network interfaces:
 #
-# * eno1: The 1.0 GB port.
-# * enp4s0: The 2.5 GB port.
-# * wlp3s0: The wifi interface.
+# * eno1 (altname enp131s0): The lower 2.5 GB port (WAN).
+# * eno2 (altname enp132s0): The upper 2.5 GB port (LAN).
+# * enx8a2fdd39918c: The BMC/IPMI management port (not managed here).
 #
 # Run `sudo netplan apply` to apply any changes made in this file.
 ##
@@ -15,7 +15,7 @@ network:
       # Nothing set here, as it's only directly used to host the br-wan bridge.
       dhcp4: false # This is the default, just including it so we have valid YAML.
     # The ethernet connection for LAN connectivity.
-    enp4s0:
+    eno2:
       # Nothing set here, as it's only directly used to host the br-lan bridge.
       dhcp4: false # This is the default, just including it so we have valid YAML.
   bridges:
@@ -33,6 +33,6 @@ network:
         - to: default
           via: 96.86.32.142
     br-lan:
-      interfaces: [enp4s0]
+      interfaces: [eno2]
       # On the Netgear R6400 router, this interface has a static assignment of 10.0.0.2.
       dhcp4: true

--- a/roles/eddings_networking/files/netplan/00-installer-config.yaml.original
+++ b/roles/eddings_networking/files/netplan/00-installer-config.yaml.original
@@ -3,6 +3,6 @@ network:
   ethernets:
     eno1:
       dhcp4: true
-    enp4s0:
+    eno2:
       dhcp4: true
   version: 2


### PR DESCRIPTION
## Summary

- Updates netplan configuration for the new ASUS Pro WS W880-ACE SE motherboard.
- Renames `enp4s0` → `eno2` in the ethernets section and `br-lan` bridge interfaces list.
- Updates interface comments to reflect actual 2.5 GB port layout (`eno1`/`eno2` with altnames) and
  documents the BMC/IPMI management port (`enx8a2fdd39918c`).

## Test plan

- [ ] SSH into `eddings` and run `sudo netplan apply`.
- [ ] Verify `br-lan` comes up with a DHCP lease (check `ip addr show br-lan`).
- [ ] Verify `br-wan` still has correct static IPs.
- [ ] Confirm internet connectivity is intact after apply.